### PR TITLE
Update node version to the latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,4 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build:
-          filters:
-            branches:
-              only: master
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/project
     docker:
-      - image: circleci/node:16.0.0-browsers
+      - image: circleci/node:latest-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/project
     docker:
-      - image: circleci/node:9.7.1-browsers
+      - image: circleci/node:16.0.0-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
To fix security issues, update node version to the latest. Also this change removes the filter not to build the branch except master.